### PR TITLE
use applicationId instead of FUSIONAUTH_APPLICATION_ID in kickstart.json

### DIFF
--- a/kickstart/kickstart.json
+++ b/kickstart/kickstart.json
@@ -68,7 +68,7 @@
           "password": "#{adminPassword}"
         },
         "registration": {
-          "applicationId": "#{FUSIONAUTH_APPLICATION_ID}",
+          "applicationId": "#{applicationId}",
           "roles": [
             "admin"
           ]


### PR DESCRIPTION
I didn't see a FUSIONAUTH_APPLICATION_ID env var referenced anywhere in the repo or [Rails guide](https://fusionauth.io/docs/quickstarts/quickstart-ruby-rails-web). I assume this is meant to be a reference to applicationId like elsewhere in the file.